### PR TITLE
Compile the crate as a cdylib, configure gradle to find it correctly.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,6 +122,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    sourceSets {
+        test.jniLibs.srcDirs += "$buildDir/rustJniLibs/desktop"
+    }
 }
 
 allprojects {
@@ -173,7 +177,7 @@ cargo {
     apiLevel = 29
 
     // Where Cargo writes its outputs.
-    targetDirectory = '../target'
+    targetDirectory = '../experiments/target'
 
     // This is the name of the library that the kotlin code
     // *must* use to import the native code

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["experiment"]
 
 [lib]
 name = "nimbus"
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 anyhow = "1"

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -10,8 +10,8 @@ license = "MPL-2.0"
 keywords = ["experiment"]
 
 [lib]
-name = "experiments"
-crate-type = ["lib"]
+name = "nimbus"
+crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"

--- a/experiments/examples/experiment.rs
+++ b/experiments/examples/experiment.rs
@@ -4,7 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
-use experiments::{AppContext, ExperimentConfig, Experiments};
+use nimbus::{AppContext, ExperimentConfig, Experiments};
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
@@ -121,7 +121,7 @@ fn main() {
             let mut uuid = uuid::Uuid::new_v4();
             while num_of_experiments_enrolled != num {
                 uuid = uuid::Uuid::new_v4();
-                num_of_experiments_enrolled = experiments::filter_enrolled(&uuid, &all_experiments)
+                num_of_experiments_enrolled = nimbus::filter_enrolled(&uuid, &all_experiments)
                     .unwrap()
                     .len()
             }


### PR DESCRIPTION
Prior to this change, `./gradlew publishToMavenLocal` was building the rust code but not packaging it as part of the `.aar`. With this change it now seems to correctly package the native code in the `.aar`, resolving the link error encountered in https://github.com/mozilla-mobile/android-components/pull/8261.

The tests in https://github.com/mozilla-mobile/android-components/pull/8261 still fail for me, but they fail with a more encouraging error:

```
uniffi.nimbus.ErrorException$RequestError: Error sending request: The rust-components network backend must be initialized before use!
```

Which seems quite reasonable TBH :-)